### PR TITLE
Added Freedesktop.org metadata

### DIFF
--- a/mMass.desktop
+++ b/mMass.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=mMass
+GenericName=Mass Spectrometry Tool
+Exec=mmass
+Icon=org.mmass.mMass
+Terminal=false
+Type=Application
+Categories=Application;Science;X-Accessories;

--- a/mmass.appdata.xml
+++ b/mmass.appdata.xml
@@ -1,0 +1,45 @@
+<?xml version='1.0' encoding='utf-8'?>
+<component type="desktop">
+  <id>org.mmass.mMass</id>
+  <name>mMass</name>
+  <summary>Open Source Mass Spectrometry Tool</summary>
+  <developer_name>Martin Strohalm</developer_name>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0</project_license>
+  <description>
+    <p>mMass supports many open formats like mzML, mzXML, mzData, MGF, ASCII and even copy n' paste from clipboard.</p>
+    <p>For data processing re-calibration, smoothing, baseline correction, auto peak picking, deconvolution are supported.</p>
+    <p>Dedicated tools allow you to generate molecular formula from given mass or compound isotopic pattern or search databases to analyze your low-mass data.</p>
+    <p>Starting with protein or peptide sequence editor you can do in-silico digestion, fragmentation or use on-line protein identification tools.</p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image type="source">http://www.mmass.org/images/features/navigation.png</image>
+    </screenshot>
+    <screenshot>
+      <image type="source">http://www.mmass.org/images/features/gelview.png</image>
+    </screenshot>
+    <screenshot>
+      <image type="source">http://www.mmass.org/images/features/normalview.png</image>
+    </screenshot>
+    <screenshot>
+      <image type="source">http://www.mmass.org/images/features/flipview.png</image>
+    </screenshot>
+    <screenshot>
+      <image type="source">http://www.mmass.org/images/features/ruler.png</image>
+    </screenshot>
+    <screenshot>
+      <image type="source">http://www.mmass.org/images/features/labelpeak.png</image>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release version="5.5.0" date="2013-07-01" type="stable"/>
+  </releases>
+  <url type="homepage">http://www.mmass.org/</url>
+  <categories>
+    <category>Science</category>
+    <category>Chemistry</category>
+    <category>ComputerScience</category>
+  </categories>
+  <content_rating type="oars-1.1"/>
+</component>


### PR DESCRIPTION
I went through the hoops to create https://github.com/flathub/flathub/pull/3738 as this was the only way of making it work on Linux. Flatpak uses the [AppStream](https://freedesktop.org/software/appstream/docs/chap-Metadata.html) and the [desktop](https://specifications.freedesktop.org/desktop-entry-spec/latest/) standard to present the application, but it is also used elsewhere in the Linux/BSD world. Submitting it upstream is therefore good practice.